### PR TITLE
BPS --> Static values for quorum and voting thresholds

### DIFF
--- a/src/events/GovernanceEvents.sol
+++ b/src/events/GovernanceEvents.sol
@@ -66,16 +66,16 @@ contract GovernanceEvents {
         address newImplementation
     );
 
-    /// @notice Emitted when proposal threshold basis points is set
+    /// @notice Emitted when proposal threshold is set
     event ProposalThresholdSet(
         uint256 oldProposalThreshold,
         uint256 newProposalThreshold
     );
 
-    /// @notice Emitted when quorum votes basis points is set
-    event QuorumVotesBPSSet(
-        uint256 oldQuorumVotesBPS,
-        uint256 newQuorumVotesBPS
+    /// @notice Emitted when quorum votes is set
+    event QuorumVotesSet(
+        uint256 oldQuorumVotes,
+        uint256 newQuorumVotes
     );
 
     event VotingRefundSet(bool status);

--- a/src/storage/GovernanceStorage.sol
+++ b/src/storage/GovernanceStorage.sol
@@ -31,11 +31,11 @@ contract GovernanceStorage {
     /// @notice The maximum setable proposal threshold
     uint256 public constant MAX_PROPOSAL_THRESHOLD = 1_000; // 1,000 basis points or 10%
 
-    /// @notice The minimum setable quorum votes basis points
-    uint256 public constant MIN_QUORUM_VOTES_BPS = 200; // 200 basis points or 2%
+    /// @notice The minimum setable quorum votes
+    uint256 public constant MIN_QUORUM_VOTES = 200; // 200 basis points or 2%
 
-    /// @notice The maximum setable quorum votes basis points
-    uint256 public constant MAX_QUORUM_VOTES_BPS = 2_000; // 2,000 basis points or 20%
+    /// @notice The maximum setable quorum votes
+    uint256 public constant MAX_QUORUM_VOTES = 2_000; // 2,000 basis points or 20%
 
     /// @notice The maximum number of actions that can be included in a proposal
     uint256 public constant proposalMaxOperations = 10; // 10 actions
@@ -56,8 +56,8 @@ contract GovernanceStorage {
     // @todo get proposal threshold value from the team
     uint256 public proposalThreshold;
 
-    /// @notice The basis point number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed. *DIFFERS from GovernerBravo
-    uint256 public quorumVotesBPS;
+    // @todo get quorum threshold value from the team
+    uint256 public quorumVotes;
 
     /// @notice Whether or not gas is refunded for casting votes.
     bool public votingRefund;


### PR DESCRIPTION
This PR migrates quorum and voting thresholds from BPS (per Nouns) to static values. The values for quorum and voting are stored in GovernanceStorage. Events for when they're updated are in GovernanceEvents (there are two). The values are initially set in `initialize` in Governance and can be updated using two setter methods. We're still snap shoting quorum and voting thresholds when a proposal is created, incase these values are updated after a proposal is created, that can't be done maliciously.