### PR TITLE
[53] set unlock time to max if it exceeds max

### DIFF
--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -357,6 +357,10 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
     if (paused) revert Paused();
     if (_unlockTime > 0 && _unlockTime < block.timestamp) revert InvalidParameter();
 
+    if (_unlockTime - block.timestamp > maxStakeTime) {
+      _unlockTime = block.timestamp + maxStakeTime;
+    }
+
     uint numTokens = _tokenIds.length;
     // This is required to ensure the gas refunds are not abused
     if (numTokens == 0) revert InvalidParameter();


### PR DESCRIPTION
My fix was slightly different from your recc, but just check for unlockTime > max + timestamp and set it to the max. 

Chose this because it allowed me to do it in the main function rather than repeating checks in each loop.