### PR TITLE
[30, 65] no approved unstakes

### DIFF
--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -462,7 +462,7 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
   /// @param _to The address to send the underlying NFT to
   function _unstakeToken(uint _tokenId, address _to) internal returns(uint) {
     address owner = ownerOf(_tokenId);
-    if (msg.sender != owner && !isApprovedForAll[owner][msg.sender] && msg.sender != getApproved[_tokenId]) revert NotAuthorized();
+    if (msg.sender != owner) revert NotAuthorized();
     if (unlockTime[_tokenId] > block.timestamp) revert TokenLocked();
     
     // Transfer the underlying token from the owner to this contract

--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -404,7 +404,7 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
     }
 
     address owner = collection.ownerOf(_tokenId);
-    if (msg.sender != owner && !collection.isApprovedForAll(owner, msg.sender) && msg.sender != collection.getApproved(_tokenId)) revert NotAuthorized();
+    if (msg.sender != owner) revert NotAuthorized();
     collection.transferFrom(owner, address(this), _tokenId);
 
     // Mint the staker a new ERC721 token representing their staked token


### PR DESCRIPTION
This fix makes it so only the owner of the staked token can unstake.

This fixes two issues:
- [65](https://github.com/sherlock-audit/2022-11-frankendao-judging/issues/65): Because the user just held the staked Frankenpunk, we don't need safeMint, as they clearly have the ability to transfer NFTs.
- [30](https://github.com/sherlock-audit/2022-11-frankendao-judging/issues/30): Now only the owner can unstake themself, so all voting power is adjusted from the correct user.