### PR TITLE
[91] change total community vp updates in _delegate

### DIFF
--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -303,13 +303,14 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
     tokenVotingPower[currentDelegate] -= amount;
     tokenVotingPower[_delegatee] += amount; 
 
-    // If a user is delegating back to themselves, they regain their community voting power, so adjust totals up
-    if (_delegator == _delegatee) {
-      _updateTotalCommunityVotingPower(_delegator, true);
+    // If this moved the current delegate down to zero voting power, then remove their community VP from the totals
+    if (tokenVotingPower[currentDelegate] == 0) {
+        _updateTotalCommunityVotingPower(currentDelegate, false);
+    }
 
-    // If a user delegates away their votes, they forfeit their community voting power, so adjust totals down
-    } else if (currentDelegate == _delegator) {
-      _updateTotalCommunityVotingPower(_delegator, false);
+    // If the new delegate previously had zero voting power, then add their community VP to the totals
+    if (tokenVotingPower[_delegatee] == amount) {
+      _updateTotalCommunityVotingPower(_delegatee, true);
     }
 
     emit DelegateChanged(_delegator, currentDelegate, _delegatee);


### PR DESCRIPTION
I believe the suggested fix was incorrect, as it would miss the tokenVotingPower of delegatee became amount, but it wasn't the delegator (ie delegating to someone who has delegating away their votes already).

Instead, I did away with checking who the people are and instead just directly assessed whether their tokenVotingPower represented the fact that they should gain or lose community VP.