### PR TITLE
[70] change base votes and monster multiplier to constants

### DIFF
--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -41,7 +41,7 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
   IGovernance governance;
 
   /// @notice Base votes for holding a Frankenpunk token
-  uint constant BASE_VOTES = 20;
+  uint constant public BASE_VOTES = 20;
 
   /// @return maxStakeBonusTime The maxmimum time you will earn bonus votes for staking for
   /// @return maxStakeBonusAmount The amount of bonus votes you'll get if you stake for the max time

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -56,7 +56,7 @@ interface IStaking {
     /////////////////////
 
     function baseTokenURI() external view returns (string memory);
-    function baseVotes() external view returns (uint256);
+    function BASE_VOTES() external view returns (uint256);
     function changeStakeAmount(uint128 _newMaxStakeBonusAmount) external;
     function changeStakeTime(uint128 _newMaxStakeBonusTime) external;
     function communityPowerMultipliers()
@@ -75,11 +75,9 @@ interface IStaking {
     function isFrankenPunksStakingContract() external pure returns (bool);
     function lastDelegatingRefund(address) external view returns (uint256);
     function lastStakingRefund(address) external view returns (uint256);
-    function monsterMultiplier() external view returns (uint256);
+    function MONSTER_MULTIPLIER() external view returns (uint256);
     function paused() external view returns (bool);
     function setBaseURI(string memory _baseURI) external;
-    function setBaseVotes(uint256 _baseVotes) external;
-    function setMonsterMultiplier(uint256 _monsterMultiplier) external;
     function setPause(bool _paused) external;
     function setProposalsCreatedMultiplier(uint64 _proposalsCreatedMultiplier) external;
     function setProposalsPassedMultiplier(uint64 _proposalsPassedMultiplier) external;

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -75,7 +75,6 @@ interface IStaking {
     function isFrankenPunksStakingContract() external pure returns (bool);
     function lastDelegatingRefund(address) external view returns (uint256);
     function lastStakingRefund(address) external view returns (uint256);
-    function MONSTER_MULTIPLIER() external view returns (uint256);
     function paused() external view returns (bool);
     function setBaseURI(string memory _baseURI) external;
     function setPause(bool _paused) external;

--- a/test/governance/ProposalData.t.sol
+++ b/test/governance/ProposalData.t.sol
@@ -71,7 +71,7 @@ contract ProposalDataTests is GovernanceBase {
             uint abstainVotes
         ) = gov.getProposalVotes(proposalId);
 
-        assert(yesVotes == staking.baseVotes() + 2);
+        assert(yesVotes == staking.BASE_VOTES() + 2);
         assert(noVotes == 0);
         assert(abstainVotes == 120);
     }

--- a/test/staking/StakingParameters.t.sol
+++ b/test/staking/StakingParameters.t.sol
@@ -5,16 +5,6 @@ import { StakingBase } from "../bases/StakingBase.t.sol";
 
 contract StakingParamsTests is StakingBase {
 
-    // Test that we can update base votes
-    function testStakingParams__UpdateBaseVotes() public {
-        uint256 newBaseVotes = staking.baseVotes() + 1;
-        
-        vm.prank(address(executor));
-        staking.setBaseVotes(newBaseVotes);
-        
-        assert(staking.baseVotes() == newBaseVotes);
-    }
-
     // Test that we can update stake bonus time.
     function testStakingParams__UpdateStakeBonusTime() public {
         (uint maxStakeBonusTime, uint maxStakeBonusAmount) = staking.stakingSettings();
@@ -37,34 +27,6 @@ contract StakingParamsTests is StakingBase {
         assert(newMaxStakeBonusAmount == maxStakeBonusAmount + 1);
     }
 
-    // Test that we can update the Monster Multiplier.
-    function testStakingParams__UpdateMonsterMultiplier() public {
-        uint256 newMonsterMultiplier = staking.monsterMultiplier() - 25;
-
-        vm.prank(address(executor));
-        staking.setMonsterMultiplier(newMonsterMultiplier);
-        
-        assert(staking.monsterMultiplier() == newMonsterMultiplier);
-    }
-
-    // Test that increasing base votes increases rewards for a staked token.
-    function testStakingParams__IncreaseBaseVotesIncreasesRewards() public {
-        uint originalBaseVotes = staking.baseVotes();
-
-        uint TOKEN_ID_1 = 0;
-        address owner1 = mockStakeSingle(TOKEN_ID_1, 0);
-        uint o1Power = staking.getTokenVotingPower(TOKEN_ID_1);
-        
-        uint newBaseVotes = originalBaseVotes + 1;
-        vm.prank(address(executor));
-        staking.setBaseVotes(newBaseVotes);
-
-        uint TOKEN_ID_2 = 10;
-        address owner2 = mockStakeSingle(TOKEN_ID_2, 0);
-        uint o2Power = staking.getTokenVotingPower(TOKEN_ID_2);
-        assert(o2Power == o1Power + 1);
-    }
-
     // Test that increasing max staked time decreases rewards for the same time commitment.
     function testStakingParams__RewardsDecreaseIfMaxStakedTimeIncreases() public {
         (uint maxStakeBonusTime, uint maxStakeBonusAmount) = staking.stakingSettings();
@@ -72,7 +34,7 @@ contract StakingParamsTests is StakingBase {
         uint TOKEN_ID_1 = 0;
         address owner1 = mockStakeSingle(TOKEN_ID_1, block.timestamp + maxStakeBonusTime);
         uint o1Power = staking.getTokenVotingPower(TOKEN_ID_1);
-        assert(o1Power == staking.baseVotes() + maxStakeBonusAmount + staking.evilBonus(TOKEN_ID_1));
+        assert(o1Power == staking.BASE_VOTES() + maxStakeBonusAmount + staking.evilBonus(TOKEN_ID_1));
         
         vm.prank(address(executor));
         staking.changeStakeTime(uint128(maxStakeBonusTime + 1 weeks));
@@ -90,7 +52,7 @@ contract StakingParamsTests is StakingBase {
         uint TOKEN_ID_1 = 0;
         address owner1 = mockStakeSingle(TOKEN_ID_1, block.timestamp + maxStakeBonusTime);
         uint o1Power = staking.getTokenVotingPower(TOKEN_ID_1);
-        assert(o1Power == staking.baseVotes() + maxStakeBonusAmount + staking.evilBonus(TOKEN_ID_1));
+        assert(o1Power == staking.BASE_VOTES() + maxStakeBonusAmount + staking.evilBonus(TOKEN_ID_1));
         
         vm.prank(address(executor));
         staking.changeStakeAmount(uint128(maxStakeBonusAmount + 10));
@@ -99,34 +61,6 @@ contract StakingParamsTests is StakingBase {
         address owner2 = mockStakeSingle(TOKEN_ID_2, block.timestamp + maxStakeBonusTime);
         uint o2Power = staking.getTokenVotingPower(TOKEN_ID_2);
         assert(o2Power > o1Power);
-    }
-
-    // Test that decreasing the Monster Multiplier decreases rewards for monsters, but doesn't impact punks.
-    function testStakingParams__DecreaseMonsterMultiplierDecreasesMonsterRewards() public {
-        uint originalMonsterMultiplier = staking.monsterMultiplier();
-
-        uint PUNK_1 = 0;
-        mockStakeSingle(PUNK_1, 0);
-        uint punkPowerBefore = staking.getTokenVotingPower(PUNK_1);
-
-        uint MONSTER_1 = 10000;
-        mockStakeSingle(MONSTER_1, 0);
-        uint monsterPowerBefore = staking.getTokenVotingPower(MONSTER_1);
-        
-        uint newMonsterMultiplier = originalMonsterMultiplier - 25;
-        vm.prank(address(executor));
-        staking.setMonsterMultiplier(newMonsterMultiplier);
-
-        uint PUNK_2 = 10;
-        mockStakeSingle(PUNK_2, 0);
-        uint punkPowerAfter = staking.getTokenVotingPower(PUNK_2);
-
-        uint MONSTER_2 = 10010;
-        address owner2 = mockStakeSingle(MONSTER_2, 0);
-        uint monsterPowerAfter = staking.getTokenVotingPower(MONSTER_2);
-
-        assert(punkPowerAfter == punkPowerBefore);
-        assert(monsterPowerAfter == monsterPowerBefore / 2);
     }
 
     // Test that increasing max staked bonus translates to increased voting power.

--- a/test/staking/VotingPower.t.sol
+++ b/test/staking/VotingPower.t.sol
@@ -15,7 +15,7 @@ contract VotingPowerTests is StakingBase {
 
         uint256 evilBonus = staking.evilBonus(PUNK_ID);
 
-        assert(staking.getVotes(staker) == staking.baseVotes() + evilBonus);
+        assert(staking.getVotes(staker) == staking.BASE_VOTES() + evilBonus);
 
         vm.prank(staker);
         staking.delegate(address(1));
@@ -25,7 +25,7 @@ contract VotingPowerTests is StakingBase {
         vm.prank(staker);
         staking.delegate(address(0));
 
-        assert(staking.getVotes(staker) == staking.baseVotes() + evilBonus);
+        assert(staking.getVotes(staker) == staking.BASE_VOTES() + evilBonus);
     }
 
     // Test that unstaking reduces voting power.
@@ -38,50 +38,11 @@ contract VotingPowerTests is StakingBase {
 
         uint256 evilBonus = staking.evilBonus(PUNK_ID);
 
-        assert(staking.getVotes(staker) == staking.baseVotes() + evilBonus);
+        assert(staking.getVotes(staker) == staking.BASE_VOTES() + evilBonus);
 
         vm.warp(block.timestamp + 28 days);
         mockUnstakeSingle(PUNK_ID);
 
         assert(staking.getVotes(staker) == 0);
     }
-
-    // @todo write test fuzzing time locked up
-    // // Test that staking for a give amount of time hits voting power it should.
-    // function testStakingVP__StakingForTimeUpdatesVotingPower() public {
-    //     address staker = frankenpunks.ownerOf(PUNK_ID);
-    //     assert(staking.getVotes(staker) == 0);
-
-    //     address owner = mockStakeSingle(PUNK_ID);
-    //     assert(owner == staker);
-
-    //     uint256 evilBonus = staking.evilBonus(PUNK_ID);
-
-    //     assert(staking.getVotes(staker) == staking.baseVotes() + evilBonus);
-
-    //     vm.prank(staker);
-    //     staking.stakeFor(PUNK_ID, 1 days);
-
-    //     assert(staking.getVotes(staker) == staking.baseVotes() + evilBonus);
-
-    //     vm.prank(staker);
-    //     staking.stakeFor(PUNK_ID, 2 days);
-
-    //     assert(staking.getVotes(staker) == 40 + evilBonus);
-
-    //     vm.prank(staker);
-    //     staking.stakeFor(PUNK_ID, 3 days);
-
-    //     assert(staking.getVotes(staker) == 60 + evilBonus);
-
-    //     vm.prank(staker);
-    //     staking.stakeFor(PUNK_ID, 4 days);
-
-    //     assert(staking.getVotes(staker) == 80 + evilBonus);
-
-    //     vm.prank(staker);
-    //     staking.stakeFor(PUNK_ID, 5 days);
-
-    //     assert(staking.getVotes(staker) == 100 + evilBonus);
-    // }
 }


### PR DESCRIPTION
Rather than saving the values as suggested by the Watson, we removed the ability to set baseVotes or monsterMultiplier. 

baseVotes is replaced with the constant BASE_VOTES.

monsterMultiplier is removed, and we simply divide by 2 when needed.