### PR TITLE
[23] ban malicious proposers trying to lock votes

### DIFF
--- a/test/governance/BanProposer.t.sol
+++ b/test/governance/BanProposer.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { GovernanceBase } from "../bases/GovernanceBase.t.sol";
+import { IGovernance } from "../../src/interfaces/IGovernance.sol";
+
+contract ActiveProposalTests is GovernanceBase {
+
+    // Test that we can ban a user and it stops them from proposing.
+    function testGovBan__BanUser() public {
+        vm.prank(FOUNDER_MULTISIG);
+        gov.banProposer(proposer, true);
+
+        vm.expectRevert(NotAuthorized.selector);
+        uint proposalId = _createProposal();
+    }
+}

--- a/test/governance/BanProposer.t.sol
+++ b/test/governance/BanProposer.t.sol
@@ -14,4 +14,14 @@ contract ActiveProposalTests is GovernanceBase {
         vm.expectRevert(NotAuthorized.selector);
         uint proposalId = _createProposal();
     }
+
+    // Test that we can ban and unban a user and they'll be able to propose.
+    function testGovBan__UnbanUser() public {
+        vm.startPrank(FOUNDER_MULTISIG);
+        gov.banProposer(proposer, true);
+        gov.banProposer(proposer, false);
+        vm.stopPrank();
+
+        _createProposal();
+    }
 }


### PR DESCRIPTION
- add banned proposer mapping
- block proposals by banned users
- add admin function to ban users (multisig or governance)
- write test to confirm it works as expected (ban and unban)