### PR TITLE
[25] Add revert to _castVotes for when staking.getVotes returns 0 (i.e. address has no voting power)

### DIFF
--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -621,6 +621,8 @@ contract Governance is IGovernance, Admin, Refundable {
         // This takes into account delegation and community voting power
         uint24 votes = (staking.getVotes(_voter)).toUint24();
 
+        if (votes == 0) revert NotEligible();
+
         // Update the proposal's total voting records based on the votes
         if (_support == 0) {
             proposal.againstVotes = proposal.againstVotes + votes;


### PR DESCRIPTION
Adds a revert to `_castVotes()` if `staking.getVotes()` returns `0`, meaning the address calling `_castVotes()` doesn't have any voting power