### PR TITLE
[12] Fix Executor cant handle 2 tx with same data

### DIFF
--- a/src/Executor.sol
+++ b/src/Executor.sol
@@ -31,9 +31,6 @@ contract Executor is IExecutor, FrankenDAOErrors {
     /// @notice The amount of time a tx can stay queued without being executed before it expires
     uint256 public constant GRACE_PERIOD = 14 days;
 
-    /// @notice The ID for the next transaction to be queued
-    uint256 public nextTransactionID;
-
     /// @notice The address of the Governance contract
     address public governance;
 
@@ -72,22 +69,20 @@ contract Executor is IExecutor, FrankenDAOErrors {
     /// @param _eta The time at which the transaction can be executed (must be at least DELAY in the future)
     /// @dev This function is only called by queue() in the Governance contract
     function queueTransaction(
+        uint256 _id,
         address _target,
         uint256 _value,
         string memory _signature,
         bytes memory _data,
         uint256 _eta
-    ) public onlyGovernance returns (bytes32 txHash, uint256 id) {
+    ) public onlyGovernance returns (bytes32 txHash) {
         if (block.timestamp + DELAY > _eta) revert DelayNotSatisfied();
 
-        id = nextTransactionID;
-        ++nextTransactionID;
-
-        txHash = keccak256(abi.encode(id, _target, _value, _signature, _data, _eta));
+        txHash = keccak256(abi.encode(_id, _target, _value, _signature, _data, _eta));
         if (queuedTransactions[txHash]) revert IdenticalTransactionAlreadyQueued();
         queuedTransactions[txHash] = true;
 
-        emit QueueTransaction(txHash, id, _target, _value, _signature, _data, _eta);
+        emit QueueTransaction(txHash, _id, _target, _value, _signature, _data, _eta);
     }
 
     /// @notice Cancel a queued transaction, preventing it from being executed

--- a/src/Executor.sol
+++ b/src/Executor.sol
@@ -30,7 +30,10 @@ contract Executor is IExecutor, FrankenDAOErrors {
 
     /// @notice The amount of time a tx can stay queued without being executed before it expires
     uint256 public constant GRACE_PERIOD = 14 days;
-    
+
+    /// @notice The ID for the next transaction to be queued
+    uint256 public nextTransactionID;
+
     /// @notice The address of the Governance contract
     address public governance;
 
@@ -74,17 +77,21 @@ contract Executor is IExecutor, FrankenDAOErrors {
         string memory _signature,
         bytes memory _data,
         uint256 _eta
-    ) public onlyGovernance returns (bytes32 txHash) {
+    ) public onlyGovernance returns (bytes32 txHash, uint256 id) {
         if (block.timestamp + DELAY > _eta) revert DelayNotSatisfied();
 
-        txHash = keccak256(abi.encode(_target, _value, _signature, _data, _eta));
+        id = nextTransactionID;
+        ++nextTransactionID;
+
+        txHash = keccak256(abi.encode(id, _target, _value, _signature, _data, _eta));
         if (queuedTransactions[txHash]) revert IdenticalTransactionAlreadyQueued();
         queuedTransactions[txHash] = true;
 
-        emit QueueTransaction(txHash, _target, _value, _signature, _data, _eta);
+        emit QueueTransaction(txHash, id, _target, _value, _signature, _data, _eta);
     }
 
     /// @notice Cancel a queued transaction, preventing it from being executed
+    /// @param _id The unique sequential ID provided for each transaction
     /// @param _target The address of the contract to execute the transaction on
     /// @param _value The amount of ETH to send with the transaction
     /// @param _signature The function signature of the transaction
@@ -93,20 +100,22 @@ contract Executor is IExecutor, FrankenDAOErrors {
     /** @dev This function is only called by _removeTransactionWithQueuedOrExpiredCheck() in the Governance contract,
             which shows up in cancel(), clear() and veto() */
     function cancelTransaction(
+        uint256 _id,
         address _target,
         uint256 _value,
         string memory _signature,
         bytes memory _data,
         uint256 _eta
     ) public onlyGovernance {
-        bytes32 txHash = keccak256(abi.encode(_target, _value, _signature, _data, _eta));
+        bytes32 txHash = keccak256(abi.encode(_id, _target, _value, _signature, _data, _eta));
         if (!queuedTransactions[txHash]) revert TransactionNotQueued();
         queuedTransactions[txHash] = false;
 
-        emit CancelTransaction(txHash, _target, _value, _signature, _data, _eta);
+        emit CancelTransaction(txHash, _id, _target, _value, _signature, _data, _eta);
     }
 
     /// @notice Executes a queued transaction after the delay has passed
+    /// @param _id The unique sequential ID provided for each transaction
     /// @param _target The address of the contract to execute the transaction on
     /// @param _value The amount of ETH to send with the transaction
     /// @param _signature The function signature of the transaction
@@ -114,21 +123,22 @@ contract Executor is IExecutor, FrankenDAOErrors {
     /// @param _eta The time at which the transaction can be executed
     /// @dev This function is only called by execute() in the Governance contract
     function executeTransaction(
+        uint256 _id,
         address _target,
         uint256 _value,
         string memory _signature,
         bytes memory _data,
         uint256 _eta
     ) public onlyGovernance returns (bytes memory) {
-        bytes32 txHash = keccak256(abi.encode(_target, _value, _signature, _data, _eta));
-        
+        bytes32 txHash = keccak256(abi.encode(_id, _target, _value, _signature, _data, _eta));
+
         // We don't need to check if it's expired, because this will be caught by the Governance contract.
         // (ie. If we are past the grace period, proposal state will be Expired and execute() will revert.)
         if (!queuedTransactions[txHash]) revert TransactionNotQueued();
         if (_eta > block.timestamp) revert TimelockNotMet();
-        
+
         queuedTransactions[txHash] = false;
-        
+
         if (bytes(_signature).length > 0) {
             _data = abi.encodePacked(bytes4(keccak256(bytes(_signature))), _data);
         }
@@ -136,7 +146,7 @@ contract Executor is IExecutor, FrankenDAOErrors {
         (bool success, bytes memory returnData) = _target.call{ value: _value }(_data);
         if (!success) revert TransactionReverted();
 
-        emit ExecuteTransaction(txHash, _target, _value, _signature, _data, _eta);
+        emit ExecuteTransaction(txHash, _id, _target, _value, _signature, _data, _eta);
         return returnData;
     }
 

--- a/src/Governance.sol
+++ b/src/Governance.sol
@@ -476,12 +476,9 @@ contract Governance is IGovernance, Admin, Refundable {
 
         // Queue separate transactions for each action in the proposal
         uint numTargets = proposal.targets.length;
-        uint256[] memory txIds = new uint[](proposal.targets.length);
         for (uint256 i = 0; i < numTargets; i++) {
-            (bytes32 txHash, uint256 id) = executor.queueTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
-            txIds[i] = id;
+            executor.queueTransaction(i, proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
         }
-        proposal.ids = txIds;
 
         // If a proposal is queued, we are ready to award the community voting power bonuses to the proposer
         ++userCommunityScoreData[proposal.proposer].proposalsCreated;
@@ -509,7 +506,7 @@ contract Governance is IGovernance, Admin, Refundable {
         // Separate transactions were queued for each action in the proposal, so execute each separately
         for (uint256 i = 0; i < proposal.targets.length; i++) {
             executor.executeTransaction(
-                proposal.ids[i], proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta
+                i, proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta
             );
         }
 
@@ -669,7 +666,7 @@ contract Governance is IGovernance, Admin, Refundable {
         ) {
             for (uint256 i = 0; i < _proposal.targets.length; i++) {
                 executor.cancelTransaction(
-                    _proposal.ids[i],
+                    i,
                     _proposal.targets[i],
                     _proposal.values[i],
                     _proposal.signatures[i],

--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -7,13 +7,13 @@ interface IExecutor {
     ////////////////////
 
     /// @notice Emited when a transaction is cancelled
-    event CancelTransaction( bytes32 indexed txHash, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
+    event CancelTransaction( bytes32 indexed txHash, uint256 id, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
     /// @notice Emited when a transaction is executed
-    event ExecuteTransaction( bytes32 indexed txHash, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
+    event ExecuteTransaction( bytes32 indexed txHash, uint256 id, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
     /// @notice Emited when a new delay value is set
     event NewDelay(uint256 indexed newDelay);
     /// @notice Emited when a transaction is queued
-    event QueueTransaction( bytes32 indexed txHash, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
+    event QueueTransaction( bytes32 indexed txHash, uint256 id, address indexed target, uint256 value, string signature, bytes data, uint256 eta);
 
     /////////////////////
     ////// Methods //////
@@ -23,11 +23,11 @@ interface IExecutor {
 
     function GRACE_PERIOD() external view returns (uint256);
 
-    function cancelTransaction( address target, uint256 value, string memory signature, bytes memory data, uint256 eta) external;
+    function cancelTransaction(uint256 _id, address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external;
 
-    function executeTransaction( address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes memory);
+    function executeTransaction(uint256 _id, address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes memory);
 
-    function queueTransaction( address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes32 txHash);
+    function queueTransaction(address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes32 txHash, uint256 id);
 
     function queuedTransactions(bytes32) external view returns (bool);
 }

--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -27,7 +27,7 @@ interface IExecutor {
 
     function executeTransaction(uint256 _id, address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes memory);
 
-    function queueTransaction(address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes32 txHash, uint256 id);
+    function queueTransaction(uint256 _id, address _target, uint256 _value, string memory _signature, bytes memory _data, uint256 _eta) external returns (bytes32 txHash);
 
     function queuedTransactions(bytes32) external view returns (bool);
 }

--- a/src/interfaces/IGovernance.sol
+++ b/src/interfaces/IGovernance.sol
@@ -50,6 +50,8 @@ interface IGovernance {
         uint96 id;
         /// @notice Creator of the proposal
         address proposer;
+        /// @notice the unique sequential transaction ids
+        uint256[] ids;
         /// @notice the ordered list of target addresses for calls to be made
         address[] targets;
         /// @notice The ordered list of values (i.e. msg.value) to be passed to the calls to be made


### PR DESCRIPTION
Make it so the Executor can handle multiple txs with the same data by adding an `_id` to the transaction hash