### PR TITLE
Add contractURI public variable, setter, and constructor arg for OS contract metadata

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -36,6 +36,7 @@ contract DeployScript is Script {
     
     bytes32 SALT = bytes32("saltysalty");
     string BASE_TOKEN_URI = "http://frankenpunks.com/uris/"; // @todo input for mainnet deployment
+    string CONTRACT_URI = "http://frankenpunks.com/uris/"; // @todo input for mainnet deployment
 
     function run() public {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
@@ -83,7 +84,8 @@ contract DeployScript is Script {
             address(executor),
             FOUNDER_MULTISIG,
             COUNCIL_MULTISIG,
-            BASE_TOKEN_URI
+            BASE_TOKEN_URI,
+            CONTRACT_URI
         );
 
         // create governance (no need to initialize because nothing vulnerable in implementation)

--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -101,6 +101,9 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
   /// @notice Base token URI for the ERC721s representing the staked position
   string public baseTokenURI;
 
+  /// @notice Contract URI for marketplace metadata
+  string public contractURI;
+
   /// @notice The total supply of staked frankenpunks
   uint128 public stakedFrankenPunks;
 
@@ -186,7 +189,8 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
     address _executor, 
     address _founders,
     address _council,
-    string memory _baseTokenURI
+    string memory _baseTokenURI,
+    string memory _contractURI
   ) ERC721("Staked FrankenPunks", "sFP") {
     frankenpunks = IERC721(_frankenpunks);
     frankenmonsters = IERC721(_frankenmonsters);
@@ -216,6 +220,9 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
 
     // Set the base token URI.
     baseTokenURI = _baseTokenURI;
+
+    // Set the contract URI.
+    contractURI = _contractURI;
   }
 
   /////////////////////////////////
@@ -242,7 +249,7 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
       ? string(abi.encodePacked(baseURI, _tokenId.toString(), ".json"))
       : "";
   }
-  
+
   /////////////////////////////////
   /////// DELEGATION LOGIC ////////
   /////////////////////////////////
@@ -617,6 +624,12 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
   /// @param _baseURI The new base URI
   function setBaseURI(string calldata _baseURI) external onlyAdmins {
     emit BaseURIChanged(baseTokenURI = _baseURI);
+  }
+
+  /// @notice Set the contract URI for marketplace metadata
+  /// @param _newContractURI The new contract URI
+  function setContractURI(string calldata _newContractURI) externaly onlyAdmins {
+    emit ContractURIChanged(contractURI = _newContractURI);
   }
 
   /// @notice Check to confirm that this is a FrankenPunks staking contract

--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -182,6 +182,8 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
   /// @param _executor The address of the DAO executor contract
   /// @param _founders The address of the founder multisig for restricted functions
   /// @param _council The address of the council multisig for restricted functions
+  /// @param _baseTokenURI Token URI for the Staking NFT contract
+  /// @param _contractURI URI for the contract metadata
   constructor(
     address _frankenpunks, 
     address _frankenmonsters,
@@ -628,7 +630,7 @@ contract Staking is IStaking, ERC721, Admin, Refundable {
 
   /// @notice Set the contract URI for marketplace metadata
   /// @param _newContractURI The new contract URI
-  function setContractURI(string calldata _newContractURI) externaly onlyAdmins {
+  function setContractURI(string calldata _newContractURI) external onlyAdmins {
     emit ContractURIChanged(contractURI = _newContractURI);
   }
 

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -12,6 +12,8 @@ interface IStaking {
     event StakingPause(bool status);
     /// @notice Emited when admins change the token's base URI
     event BaseURIChanged(string _baseURI);
+    /// @notice Emited when the contract URI is updated
+    event ContractURIChanged(string _contractURI);
     /// @notice Emited when refund settings are updated
     event RefundSettingsChanged(bool _stakingRefund, bool _delegatingRefund, uint256 _newCooldown);
     /// @notice Emited when FrankenMonster voting multiplier is changed

--- a/test/governance/UpgradeStaking.t.sol
+++ b/test/governance/UpgradeStaking.t.sol
@@ -16,7 +16,8 @@ contract UpgradeStakingTests is GovernanceBase {
             address(executor),
             FOUNDER_MULTISIG,
             COUNCIL_MULTISIG,
-            BASE_TOKEN_URI
+            BASE_TOKEN_URI,
+            CONTRACT_URI
         ));
 
         uint proposalId = _passCustomProposal("setStakingAddress(address)", abi.encode(fakeStaking));

--- a/test/staking/TokenURIs.t.sol
+++ b/test/staking/TokenURIs.t.sol
@@ -6,26 +6,67 @@ import { StakingBase } from "../bases/StakingBase.t.sol";
 contract TokenURITests is StakingBase {
     // Test that a staked token has a URI.
     function testTokenURI__StakedTokenHasCorrectURI() public {
-        uint TOKEN_ID = 0;
+        uint256 TOKEN_ID = 0;
         string memory TOKEN_ID_STRING = "0";
 
         mockStakeSingle(TOKEN_ID, 0);
 
         assert(
-            keccak256(bytes(staking.tokenURI(TOKEN_ID))) == 
-            keccak256(bytes(string(abi.encodePacked(BASE_TOKEN_URI, TOKEN_ID_STRING, ".json"))))
+            keccak256(bytes(staking.tokenURI(TOKEN_ID))) ==
+                keccak256(
+                    bytes(
+                        string(
+                            abi.encodePacked(
+                                BASE_TOKEN_URI,
+                                TOKEN_ID_STRING,
+                                ".json"
+                            )
+                        )
+                    )
+                )
         );
     }
 
     function testTokenURI__StakedMonsterHasCorrectURI() public {
-        uint TOKEN_ID = 15000;
+        uint256 TOKEN_ID = 15000;
         string memory TOKEN_ID_STRING = "15000";
 
         mockStakeSingle(TOKEN_ID, 0);
-        
+
         assert(
-            keccak256(bytes(staking.tokenURI(TOKEN_ID))) == 
-            keccak256(bytes(string(abi.encodePacked(BASE_TOKEN_URI, TOKEN_ID_STRING, ".json"))))
+            keccak256(bytes(staking.tokenURI(TOKEN_ID))) ==
+                keccak256(
+                    bytes(
+                        string(
+                            abi.encodePacked(
+                                BASE_TOKEN_URI,
+                                TOKEN_ID_STRING,
+                                ".json"
+                            )
+                        )
+                    )
+                )
+        );
+    }
+
+    // Test that the contract URI is set on creation
+    function testTokenURI__StakingContractHasContractURI() public {
+        assertEq(
+            keccak256(bytes(staking.contractURI())),
+            keccak256(bytes(CONTRACT_URI))
+        );
+    }
+
+    // Test that setContractURI updates the contract URI
+    function testTokenURI__SetContractURIUpdatesTokenUri() public {
+        string memory NEW_CONTRACT_URI = "https://frankenpunks.com/other-uris/";
+
+        vm.prank(COUNCIL_MULTISIG);
+        staking.setContractURI(NEW_CONTRACT_URI);
+
+        assertEq(
+            keccak256(bytes(staking.contractURI())),
+            keccak256(bytes(NEW_CONTRACT_URI))
         );
     }
 }


### PR DESCRIPTION
This pull request adds a `contractURI` variable (with a setter) for the contract metadata ([OS docs here](https://docs.opensea.io/docs/contract-level-metadata))